### PR TITLE
disable MCCP due to observed bugs in library

### DIFF
--- a/telnet.h
+++ b/telnet.h
@@ -44,6 +44,9 @@
 #define MCCP
 #endif
 
+#undef MCCP
+// MCCP disabled due to bugs in library
+
 #ifdef MCCP
 #include "mccpDecompress.h"
 #endif


### PR DESCRIPTION
 'cos i've just realised that that mccpDecompress.c we're using does lookahead and it shouldn't